### PR TITLE
joinSubcomponents Code Template

### DIFF
--- a/Code Templates/Join HL7 Subcomponents/Join HL7 Subcomponents.js
+++ b/Code Templates/Join HL7 Subcomponents/Join HL7 Subcomponents.js
@@ -1,0 +1,23 @@
+/**
+	Returns the string representation of each child element of <b>xml</b> joined by
+	<b>separator</b>. If <b>xml</b> contains no child elements, the string
+	representation of <b>xml</b> will be returned instead.
+
+	@copyright 2018 Tony Germano
+	@license MPL-2.0
+
+	@param {XML} xml - The e4x xml node representing a field component.
+	@param {String} separator - Optional character used to join sub-components. Default: '&'.
+	@return {String} 
+*/
+function joinSubcomponents(xml, separator)  {
+	if (typeof separator == 'undefined') separator = '&';
+	if (xml.hasComplexContent()) {
+		var content = [];
+		for each (var child in xml.children()) {
+			content.push(child.toString());
+		}
+		xml = content.join(separator);
+	} 
+	return xml.toString();
+}

--- a/Code Templates/Join HL7 Subcomponents/Join HL7 Subcomponents.xml
+++ b/Code Templates/Join HL7 Subcomponents/Join HL7 Subcomponents.xml
@@ -1,0 +1,32 @@
+<list>
+  <codeTemplate version="3.0.2">
+    <id>aab23d47-cae1-4a03-9317-27246e5cf808</id>
+    <name>joinSubcomponents</name>
+    <tooltip></tooltip>
+    <code>/**
+	Returns the string representation of each child element of &lt;b&gt;xml&lt;/b&gt; joined by
+	&lt;b&gt;separator&lt;/b&gt;. If &lt;b&gt;xml&lt;/b&gt; contains no child elements, the string
+	representation of &lt;b&gt;xml&lt;/b&gt; will be returned instead.
+
+	@copyright 2018 Tony Germano
+	@license MPL-2.0
+
+	@param {XML} xml - The e4x xml node representing an HL7 field component.
+	@param {String} separator - Optional character used to join sub-components. Default: &apos;&amp;&apos;.
+	@return {String} 
+*/
+function joinSubcomponents(xml, separator)  {
+	if (typeof separator == &apos;undefined&apos;) separator = &apos;&amp;&apos;;
+	if (xml.hasComplexContent()) {
+		var content = [];
+		for each (var child in xml.children()) {
+			content.push(child.toString());
+		}
+		xml = content.join(separator);
+	} 
+	return xml.toString();
+}</code>
+    <type>FUNCTION</type>
+    <scope>3</scope>
+  </codeTemplate>
+</list>

--- a/Code Templates/Join HL7 Subcomponents/LICENSE
+++ b/Code Templates/Join HL7 Subcomponents/LICENSE
@@ -1,0 +1,5 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Files in this subfolder are Copyright Tony Germano 2018.

--- a/Code Templates/Join HL7 Subcomponents/README.md
+++ b/Code Templates/Join HL7 Subcomponents/README.md
@@ -1,0 +1,14 @@
+# Join HL7 Subcomponents
+Takes one or two parameters. Returns the text of all subcomponents of the given HL7 component joined by the given separator or `&` if none is provided. Returns the text of the component if it contains no sub-components. Useful for fields where the subcomponent separator has not been escaped.
+
+### Parameters:
+
+- **xml:** The e4x xml node representing an HL7 field component.
+- **separator:** Optional character used to join subcomponents. Default: `&`.
+
+### Examples
+The patient street address sometimes contains an ampersand and gets broken into subcomponents.
+
+```javascript
+msg['PID']['PID.11']['PID.11.1'] = joinSubcomponents(msg['PID']['PID.11']['PID.11.1']);
+```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a repository of example channels, code templates, and other scripts you 
  - Fix HL7 Node Order
  - Get Num Pages In PDF
  - Get Segments After a Particular Segment
+ - Join HL7 Sub-components
  - Overwrite Logger Categories
  - Rename HL7 Field
  - Replace in All Descendant XML Nodes


### PR DESCRIPTION
Takes one or two parameters. Returns the text of all subcomponents of the given HL7 component joined by the given separator or `&` if none is provided. Returns the text of the component if it contains no sub-components. Useful for fields where the subcomponent separator has not been escaped.
