### PR TITLE
Run on Startup

### DIFF
--- a/Code Templates/Run on Startup/LICENSE
+++ b/Code Templates/Run on Startup/LICENSE
@@ -2,4 +2,4 @@ This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-Files in this subfolder are Copyright Tony Germano 2018.
+Files in this subfolder are Copyright Tony Germano 2019.

--- a/Code Templates/Run on Startup/LICENSE
+++ b/Code Templates/Run on Startup/LICENSE
@@ -1,0 +1,5 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Files in this subfolder are Copyright Tony Germano 2018.

--- a/Code Templates/Run on Startup/README.md
+++ b/Code Templates/Run on Startup/README.md
@@ -1,0 +1,13 @@
+# Run on Startup
+Simply sets the boolean variable `isInitialDeploy` to `true` if Connect is still starting up and `false` otherwise. This is only useful in the Deploy scripts (Global or Channel.)
+
+### Examples
+Log a certain message from the Global Deploy Script only during startup.
+
+```javascript
+if (isInitialDeploy) {
+	logger.info('THIS IS THE FIRST TIME THE GLOBAL DEPLOY IS RUNNING!');
+}
+
+logger.info('This happens every time the global deploy runs.');
+```

--- a/Code Templates/Run on Startup/Run on Startup.js
+++ b/Code Templates/Run on Startup/Run on Startup.js
@@ -1,0 +1,5 @@
+const isInitialDeploy = (function() {
+    const ConfigurationController = com.mirth.connect.server.controllers.ConfigurationController;
+    const configurationController = ConfigurationController.getInstance();
+    return configurationController.getStatus() == ConfigurationController.STATUS_INITIAL_DEPLOY;
+}());

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a repository of example channels, code templates, and other scripts you 
  - Overwrite Logger Categories
  - Rename HL7 Field
  - Replace in All Descendant XML Nodes
+ - Run on Startup
  - Strip Empty Nodes from XML
  - Unescape `\Xdd..\` HL7 Sequences
 


### PR DESCRIPTION
Simply sets the boolean variable `isInitialDeploy` to `true` if Connect is still starting up and `false` otherwise. This is only useful in the Deploy scripts (Global or Channel.)